### PR TITLE
Add attenuation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,12 +25,11 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "biscuit-auth"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c9239a8eaf2226ef7601c4de115ae87f86b3e7fde58e6ff300cabe609f2c72"
+checksum = "c228b64fb7733d0ec787c23f06597318615fa7a9045199213a266c5155aa0299"
 dependencies = [
  "base64",
- "chrono",
  "ed25519-dalek",
  "getrandom",
  "hex",
@@ -49,13 +42,14 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror",
+ "time",
  "wasm-bindgen",
  "zeroize",
 ]
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64",
  "biscuit-auth",
@@ -108,19 +102,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -211,7 +192,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -296,22 +277,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
+name = "num_threads"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
+ "libc",
 ]
 
 [[package]]
@@ -542,13 +513,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "num_threads",
 ]
 
 [[package]]
@@ -574,12 +545,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64",
  "biscuit-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
-biscuit-auth = { version = "2.0.0", features = ["wasm", "serde-error"] }
+biscuit-auth = { version = "2.0.1", features = ["wasm", "serde-error"] }
 rand = "0.7"
 log = "0.4"
 wasm-logger = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {}}: with pkgs;
+
+mkShell {
+  buildInputs = [ rustup ];
+}

--- a/src/attenuate.rs
+++ b/src/attenuate.rs
@@ -1,0 +1,89 @@
+use biscuit_auth::{
+    error,
+    parser::{parse_block_source, SourceResult},
+    UnverifiedBiscuit,
+};
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+use wasm_bindgen::prelude::*;
+
+use crate::{get_parse_errors, ParseErrors};
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+struct AttenuateTokenQuery {
+    pub token: String,
+    pub blocks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum AttenuationError {
+    BlockParseErrors(ParseErrors),
+    Biscuit(error::Token),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AttenuateTokenResult {
+    pub attenuated: Result<String, AttenuationError>,
+}
+
+#[wasm_bindgen]
+pub fn attenuate_token(query: &JsValue) -> JsValue {
+    let query = query.into_serde().unwrap();
+
+    let result = attenuate_token_inner(query);
+
+    JsValue::from_serde(&result).unwrap()
+}
+
+fn attenuate_token_inner(query: AttenuateTokenQuery) -> Result<String, AttenuationError> {
+    let token =
+        UnverifiedBiscuit::from_base64(&query.token).map_err(|e| AttenuationError::Biscuit(e))?;
+
+    let mut parse_errors = ParseErrors::new();
+    let mut has_errors = false;
+    let mut blocks = vec![];
+
+    for code in query.blocks.iter() {
+        match parse_block_source(&code) {
+            Err(errors) => {
+                parse_errors.blocks.push(get_parse_errors(&code, &errors));
+                has_errors = true;
+            }
+            Ok(block) => {
+                blocks.push(block);
+                parse_errors.blocks.push(Vec::new());
+            }
+        }
+    }
+
+    if has_errors {
+        Err(AttenuationError::BlockParseErrors(parse_errors))
+    } else {
+        attenuate_token_from_blocks(&token, blocks).map_err(AttenuationError::Biscuit)
+    }
+}
+
+fn attenuate_token_from_blocks(
+    token: &UnverifiedBiscuit,
+    blocks: Vec<SourceResult>,
+) -> Result<String, error::Token> {
+    let mut output = token.clone();
+    for block_parsed in &blocks {
+        let mut builder = token.create_block();
+
+        for (_, fact) in block_parsed.facts.iter() {
+            builder.add_fact(fact.clone()).unwrap();
+        }
+
+        for (_, rule) in block_parsed.rules.iter() {
+            builder.add_rule(rule.clone()).unwrap();
+        }
+
+        for (_, check) in block_parsed.checks.iter() {
+            builder.add_check(check.clone()).unwrap();
+        }
+
+        output = output.append(builder)?;
+    }
+    Ok(output.to_base64()?)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,14 @@ use serde::{Deserialize, Serialize};
 use std::default::Default;
 use wasm_bindgen::prelude::*;
 
+mod attenuate;
 mod execute;
 mod generate_token;
 mod parse_token;
 pub use execute::execute;
 pub use generate_token::generate_token;
 pub use parse_token::parse_token;
+pub use attenuate::attenuate_token;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,8 @@
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/biscuit-auth/biscuit-component-wasm",
   "repository": {
     "type": "git",
     "url": "https://github.com/biscuit-auth/biscuit-component-wasm"


### PR DESCRIPTION
It's quite similar to `generate_token`, but its code was not amenable to
reuse, so there is a bit of copy-paste. I think things could/should be
improved on this front but it's not critical.

It's been tested locally with https://github.com/biscuit-auth/biscuit-web-components/pull/21