### PR TITLE
Bump biscuit-auth dep to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "biscuit-auth"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c228b64fb7733d0ec787c23f06597318615fa7a9045199213a266c5155aa0299"
+checksum = "4bbb36e3ce26459005ce53ae70777060bf5f207f4490e62e0b01869df293ef21"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
-biscuit-auth = { version = "2.0.1", features = ["wasm", "serde-error"] }
+biscuit-auth = { version = "2.1.0", features = ["wasm", "serde-error"] }
 rand = "0.7"
 log = "0.4"
 wasm-logger = "0.2"

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {}}: with pkgs;
 
 mkShell {
-  buildInputs = [ rustup ];
+  buildInputs = [ rustup nodejs-16_x ];
 }


### PR DESCRIPTION
To conform to the latest spec v2 updates