### PR TITLE
Support for 3rd party tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "base64"
@@ -25,11 +25,12 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "biscuit-auth"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbb36e3ce26459005ce53ae70777060bf5f207f4490e62e0b01869df293ef21"
+version = "3.0.0-alpha1"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
 dependencies = [
  "base64",
+ "biscuit-parser",
+ "biscuit-quote",
  "ed25519-dalek",
  "getrandom",
  "hex",
@@ -48,11 +49,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "biscuit-parser"
+version = "0.1.0-alpha1"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
+dependencies = [
+ "hex",
+ "nom",
+ "quote",
+ "serde",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "biscuit-quote"
+version = "0.2.0-alpha1"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
+dependencies = [
+ "biscuit-parser",
+ "proc-macro-error",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "biscuit-wasm-support"
 version = "0.3.6"
 dependencies = [
  "base64",
  "biscuit-auth",
+ "biscuit-parser",
  "console_error_panic_hook",
  "hex",
  "log",
@@ -75,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -87,9 +113,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cfg-if"
@@ -115,18 +141,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest",
@@ -146,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -169,15 +195,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -213,45 +239,39 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory_units"
@@ -267,23 +287,28 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -298,19 +323,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "unicode-xid",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -318,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
@@ -331,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",
@@ -341,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -391,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -402,30 +451,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -434,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -458,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 
 [[package]]
 name = "subtle"
@@ -470,13 +519,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -493,18 +542,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -513,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
  "libc",
@@ -529,10 +578,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "version_check"
@@ -548,9 +603,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -560,13 +615,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -575,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -585,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -598,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-logger"
@@ -615,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -659,18 +714,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "3.0.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
 dependencies = [
  "base64",
  "biscuit-parser",
@@ -51,7 +51,7 @@ dependencies = [
 [[package]]
 name = "biscuit-parser"
 version = "0.1.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
 dependencies = [
  "hex",
  "nom",
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.2.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#680f848fb9dd6d7d2dbf6c54ab46770048b3e825"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.3.6"
+version = "0.4.0-alpha1"
 dependencies = [
  "base64",
  "biscuit-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "biscuit-auth"
 version = "3.0.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#f38d100da35605464fa4423f0cbd3c71463d5c39"
 dependencies = [
  "base64",
  "biscuit-parser",
@@ -51,7 +51,7 @@ dependencies = [
 [[package]]
 name = "biscuit-parser"
 version = "0.1.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#f38d100da35605464fa4423f0cbd3c71463d5c39"
 dependencies = [
  "hex",
  "nom",
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.2.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#62d49d48277efccd472e68b0fa7e75fa3fc9ebc8"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#f38d100da35605464fa4423f0cbd3c71463d5c39"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
-biscuit-auth = { version = "2.1.0", features = ["wasm", "serde-error"] }
+biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "master", features = ["wasm", "serde-error"] }
+biscuit-parser= { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "master", features = ["serde-error"] }
 rand = "0.7"
 log = "0.4"
 wasm-logger = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.3.6"
+version = "0.4.0-alpha1"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/attenuate.rs
+++ b/src/attenuate.rs
@@ -1,4 +1,5 @@
 use biscuit_auth::{
+    builder::BlockBuilder,
     error,
     parser::{parse_block_source, SourceResult},
     UnverifiedBiscuit,
@@ -69,7 +70,7 @@ fn attenuate_token_from_blocks(
 ) -> Result<String, error::Token> {
     let mut output = token.clone();
     for block_parsed in &blocks {
-        let mut builder = token.create_block();
+        let mut builder = BlockBuilder::new();
 
         for (_, fact) in block_parsed.facts.iter() {
             builder.add_fact(fact.clone()).unwrap();

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,16 +1,7 @@
 use crate::execute_serialized;
 use crate::generate_token;
-use crate::{
-    get_parse_errors, get_position, log, Editor, Fact, Marker, ParseErrors, SourcePosition,
-};
-use biscuit_auth::{
-    builder,
-    datalog::SymbolTable,
-    error,
-    parser::{parse_block_source, parse_source},
-    Authorizer, AuthorizerLimits, Biscuit, KeyPair,
-};
-use log::*;
+use crate::{Editor, Fact, ParseErrors};
+use biscuit_auth::{error, KeyPair};
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::default::Default;

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -255,7 +255,7 @@ fn perform_authorization(
         // todo check what the origin should be
         if !query.is_empty() {
             let query_result: Result<Vec<builder::Fact>, biscuit_auth::error::Token> =
-                authorizer.query(query.as_str(), &[0].iter().collect());
+                authorizer.query(query.as_str());
             match query_result {
                 Err(e) => {
                     log(&format!("query error: {:?}", e));

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use biscuit_auth::{
     builder, error, parser::parse_block_source, parser::parse_source, parser::SourceResult,
-    Authorizer, AuthorizerLimits, Biscuit, PublicKey, UnverifiedBiscuit,
+    AuthorizerLimits, Biscuit, PublicKey,
 };
 use serde::{Deserialize, Serialize};
 use std::default::Default;
@@ -66,11 +66,8 @@ pub fn execute_serialized(query: &JsValue) -> JsValue {
 }
 
 fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors> {
-    let public_key = hex::decode(&query.root_public_key)
-        .map_err(|_| error::Token::InternalError)
-        .and_then(|pk_bytes| {
-            PublicKey::from_bytes(&pk_bytes).map_err(|_| error::Token::InternalError)
-        });
+    let public_key =
+        PublicKey::from_bytes_hex(&query.root_public_key).map_err(|_| error::Token::InternalError);
 
     let deser: Result<Biscuit, error::Token> = public_key
         .clone()

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -1,0 +1,301 @@
+use crate::{
+    get_parse_errors, get_position, log, Editor, Fact, Marker, ParseError, SourcePosition,
+};
+use biscuit_auth::{
+    builder, error, parser::parse_block_source, parser::parse_source, parser::SourceResult,
+    Authorizer, AuthorizerLimits, Biscuit, PublicKey, UnverifiedBiscuit,
+};
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+use wasm_bindgen::prelude::*;
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct BiscuitQuery {
+    pub token: String,
+    pub root_public_key: String,
+    pub authorizer_code: String,
+    pub query: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BiscuitResult {
+    pub token_blocks: Vec<Editor>,
+    pub authorizer_editor: Editor,
+    pub authorizer_result: Result<usize, error::Token>,
+    pub authorizer_world: Vec<Fact>,
+    pub query_result: Vec<Fact>,
+}
+
+impl Default for BiscuitResult {
+    fn default() -> Self {
+        BiscuitResult {
+            token_blocks: Vec::new(),
+            authorizer_editor: Editor::default(),
+            authorizer_result: Ok(0),
+            authorizer_world: Vec::new(),
+            query_result: Vec::new(),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteErrors {
+    pub root_key: Option<String>,
+    pub token: Option<String>,
+    pub authorizer: Vec<ParseError>,
+}
+
+#[derive(Clone, Debug)]
+struct Block {
+    pub checks: Vec<(SourcePosition, bool)>,
+}
+
+impl Default for Block {
+    fn default() -> Self {
+        Block { checks: Vec::new() }
+    }
+}
+
+#[wasm_bindgen]
+pub fn execute_serialized(query: &JsValue) -> JsValue {
+    let query: BiscuitQuery = query.into_serde().unwrap();
+
+    let result = execute_inner(query);
+
+    JsValue::from_serde(&result).unwrap()
+}
+
+fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors> {
+    let public_key = hex::decode(&query.root_public_key)
+        .map_err(|_| error::Token::InternalError)
+        .and_then(|pk_bytes| {
+            PublicKey::from_bytes(&pk_bytes).map_err(|_| error::Token::InternalError)
+        });
+
+    let deser: Result<Biscuit, error::Token> = public_key
+        .clone()
+        .and_then(|pk| Biscuit::from_base64(&query.token, |_| pk));
+
+    let authorizer = parse_authorizer(&query.authorizer_code);
+
+    match (&deser, &authorizer) {
+        (Ok(token), Ok(authorizer_source)) => Ok(perform_authorization(
+            &token,
+            &query.authorizer_code,
+            &authorizer_source,
+            &query.query,
+        )),
+        _ => Err(ExecuteErrors {
+            root_key: public_key.err().map(|e| e.to_string()),
+            token: deser.err().map(|e| e.to_string()),
+            authorizer: authorizer.err().unwrap_or(Vec::new()),
+        }),
+    }
+}
+
+fn perform_authorization(
+    token: &Biscuit,
+    authorizer_code: &str,
+    authorizer_source: &SourceResult,
+    query: &Option<String>,
+) -> BiscuitResult {
+    let mut biscuit_result = BiscuitResult::default();
+
+    let mut authority = gather_checks(&token.print_block_source(0).unwrap());
+    biscuit_result.token_blocks.push(Editor::default());
+
+    let mut blocks = Vec::new();
+    for i in 1..token.block_count() {
+        blocks.push(gather_checks(&token.print_block_source(i).unwrap()));
+        biscuit_result.token_blocks.push(Editor::default());
+    }
+
+    let mut authorizer = token.authorizer().unwrap();
+    let mut authorizer_checks = Vec::new();
+    let mut authorizer_policies = Vec::new();
+
+    for (_, fact) in authorizer_source.facts.iter() {
+        authorizer.add_fact(fact.clone()).unwrap();
+    }
+
+    for (_, rule) in authorizer_source.rules.iter() {
+        authorizer.add_rule(rule.clone()).unwrap();
+    }
+
+    for (i, check) in authorizer_source.checks.iter() {
+        authorizer.add_check(check.clone()).unwrap();
+        let position = get_position(&authorizer_code, i);
+        // checks are marked as success until they fail
+        authorizer_checks.push((position, true));
+    }
+
+    for (i, policy) in authorizer_source.policies.iter() {
+        authorizer.add_policy(policy.clone()).unwrap();
+        let position = get_position(&authorizer_code, i);
+        authorizer_policies.push(position);
+    }
+
+    let mut limits = AuthorizerLimits::default();
+    limits.max_time = std::time::Duration::from_secs(2);
+    let authorizer_result = authorizer.authorize_with_limits(limits);
+
+    // todo extract scope information as well
+    let (mut facts, _, _, _) = authorizer.dump();
+    biscuit_result.authorizer_world = facts
+        .drain(..)
+        .map(|mut fact| Fact {
+            name: fact.predicate.name,
+            terms: fact
+                .predicate
+                .terms
+                .drain(..)
+                .map(|term| term.to_string())
+                .collect(),
+        })
+        .collect();
+    match &authorizer_result {
+        Err(error::Token::FailedLogic(error::Logic::Unauthorized { policy, checks })) => {
+            for e in checks.iter() {
+                match e {
+                    error::FailedCheck::Authorizer(error::FailedAuthorizerCheck {
+                        check_id,
+                        ..
+                    }) => {
+                        authorizer_checks[*check_id as usize].1 = false;
+                    }
+                    error::FailedCheck::Block(error::FailedBlockCheck {
+                        block_id,
+                        check_id,
+                        ..
+                    }) => {
+                        let block = if *block_id == 0 {
+                            &mut authority
+                        } else {
+                            &mut blocks[*block_id as usize - 1]
+                        };
+                        block.checks[*check_id as usize].1 = false;
+                    }
+                }
+            }
+            match policy {
+                error::MatchedPolicy::Deny(index) => {
+                    let position = &authorizer_policies[*index];
+                    biscuit_result.authorizer_editor.markers.push(Marker {
+                        ok: false,
+                        position: position.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Err(error::Token::FailedLogic(error::Logic::NoMatchingPolicy { checks })) => {
+            for e in checks.iter() {
+                match e {
+                    error::FailedCheck::Authorizer(error::FailedAuthorizerCheck {
+                        check_id,
+                        ..
+                    }) => {
+                        authorizer_checks[*check_id as usize].1 = false;
+                    }
+                    error::FailedCheck::Block(error::FailedBlockCheck {
+                        block_id,
+                        check_id,
+                        ..
+                    }) => {
+                        let block = if *block_id == 0 {
+                            &mut authority
+                        } else {
+                            &mut blocks[*block_id as usize - 1]
+                        };
+                        block.checks[*check_id as usize].1 = false;
+                    }
+                }
+            }
+        }
+        Ok(index) => {
+            let position = &authorizer_policies[*index];
+            biscuit_result.authorizer_editor.markers.push(Marker {
+                ok: true,
+                position: position.clone(),
+            });
+        }
+        // other errors are ignored. they should not happen at this point
+        Err(_) => {}
+    }
+
+    for (position, result) in authority.checks.iter() {
+        if let Some(ed) = biscuit_result.token_blocks.get_mut(0) {
+            ed.markers.push(Marker {
+                ok: *result,
+                position: position.clone(),
+            });
+        }
+    }
+
+    for (id, block) in blocks.iter().enumerate() {
+        for (position, result) in block.checks.iter() {
+            if let Some(ed) = biscuit_result.token_blocks.get_mut(id + 1) {
+                ed.markers.push(Marker {
+                    ok: *result,
+                    position: position.clone(),
+                });
+            }
+        }
+    }
+
+    for (position, result) in authorizer_checks.iter() {
+        biscuit_result.authorizer_editor.markers.push(Marker {
+            ok: *result,
+            position: position.clone(),
+        });
+    }
+
+    biscuit_result.authorizer_result = authorizer_result;
+
+    if let Some(query) = query.as_ref() {
+        log(&format!("got query content: {}", query));
+
+        // todo check what the origin should be
+        if !query.is_empty() {
+            let query_result: Result<Vec<builder::Fact>, biscuit_auth::error::Token> =
+                authorizer.query(query.as_str(), &[0].iter().collect());
+            match query_result {
+                Err(e) => {
+                    log(&format!("query error: {:?}", e));
+                }
+                Ok(mut facts) => {
+                    biscuit_result.query_result = facts
+                        .drain(..)
+                        .map(|mut fact| Fact {
+                            name: fact.predicate.name,
+                            terms: fact
+                                .predicate
+                                .terms
+                                .drain(..)
+                                .map(|term| term.to_string())
+                                .collect(),
+                        })
+                        .collect();
+                }
+            }
+        }
+    }
+    biscuit_result
+}
+
+fn parse_authorizer(authorizer_code: &str) -> Result<SourceResult, Vec<ParseError>> {
+    parse_source(&authorizer_code).map_err(|errors| get_parse_errors(&authorizer_code, &errors))
+}
+
+// extract checks with their positions
+fn gather_checks(block_source: &str) -> Block {
+    let mut block = Block::default();
+    if let Ok(result) = parse_block_source(block_source) {
+        for (i, _) in result.checks.iter() {
+            let position = get_position(block_source, i);
+            block.checks.push((position, true));
+        }
+    }
+
+    block
+}

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -65,7 +65,7 @@ pub fn execute_serialized(query: &JsValue) -> JsValue {
     JsValue::from_serde(&result).unwrap()
 }
 
-fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors> {
+pub fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors> {
     let public_key =
         PublicKey::from_bytes_hex(&query.root_public_key).map_err(|_| error::Token::InternalError);
 

--- a/src/generate_token.rs
+++ b/src/generate_token.rs
@@ -32,8 +32,8 @@ pub fn generate_keypair() -> JsValue {
     let kp = KeyPair::new();
 
     JsValue::from_serde(&KeyPairJs {
-        private_key: hex::encode(kp.private().to_bytes()),
-        public_key: hex::encode(kp.public().to_bytes()),
+        private_key: kp.private().to_bytes_hex(),
+        public_key: kp.public().to_bytes_hex(),
     })
     .unwrap()
 }
@@ -78,9 +78,7 @@ fn generate_token_from_blocks(
     query: &GenerateToken,
     blocks: Vec<SourceResult>,
 ) -> Result<String, error::Token> {
-    let data = hex::decode(&query.private_key).map_err(|_| error::Token::InternalError)?;
-
-    let keypair = KeyPair::from(PrivateKey::from_bytes(&data)?);
+    let keypair = KeyPair::from(PrivateKey::from_bytes_hex(&query.private_key)?);
     let mut builder = Biscuit::builder();
 
     let authority_parsed = &blocks[0];

--- a/src/generate_token.rs
+++ b/src/generate_token.rs
@@ -46,7 +46,7 @@ pub fn generate_token(query: &JsValue) -> Result<String, JsValue> {
     generate_token_inner(query).map_err(|e| JsValue::from_serde(&e).unwrap())
 }
 
-fn generate_token_inner(query: GenerateToken) -> Result<String, GenerateTokenError> {
+pub fn generate_token_inner(query: GenerateToken) -> Result<String, GenerateTokenError> {
     let mut parse_errors = ParseErrors::new();
     let mut blocks = Vec::new();
     let mut has_errors = false;

--- a/src/generate_token.rs
+++ b/src/generate_token.rs
@@ -79,7 +79,7 @@ pub fn generate_token_inner(query: GenerateToken) -> Result<String, GenerateToke
                 let res = ok.map(|k| {
                     PrivateKey::from_bytes_hex(&k)
                         .map_err(|_| GenerateTokenError::Biscuit(error::Token::InternalError))
-                        .map(|pk| KeyPair::from(pk))
+                        .map(|pk| KeyPair::from(&pk))
                 });
                 res.transpose()
             })
@@ -98,7 +98,7 @@ fn generate_token_from_blocks(
     blocks: Vec<SourceResult>,
     external_private_keys: Vec<Option<KeyPair>>,
 ) -> Result<String, error::Token> {
-    let keypair = KeyPair::from(PrivateKey::from_bytes_hex(&query.private_key)?);
+    let keypair = KeyPair::from(&PrivateKey::from_bytes_hex(&query.private_key)?);
     let mut builder = Biscuit::builder();
 
     let authority_parsed = &blocks[0];
@@ -138,7 +138,7 @@ fn generate_token_from_blocks(
                 builder.add_check(check.clone()).unwrap();
             }
 
-            let block = req.create_block(epk.private(), builder)?;
+            let block = req.create_block(&epk.private(), builder)?;
             token = token.append_third_party(epk.public(), block)?;
         } else {
             let mut builder = BlockBuilder::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@ use wasm_bindgen::prelude::*;
 
 mod attenuate;
 mod execute;
+mod execute_serialized;
 mod generate_token;
 mod parse_token;
+pub use attenuate::attenuate_token;
 pub use execute::execute;
 pub use generate_token::generate_token;
 pub use parse_token::parse_token;
-pub use attenuate::attenuate_token;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/src/parse_token.rs
+++ b/src/parse_token.rs
@@ -11,8 +11,8 @@ struct ParseTokenQuery {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 struct ParseResult {
     pub token_blocks: Vec<String>,
-    //pub key: String,
     pub revocation_ids: Vec<String>,
+    pub external_keys: Vec<Option<String>>,
     pub error: Option<String>,
 }
 
@@ -45,10 +45,17 @@ fn parse_token_inner(query: ParseTokenQuery) -> ParseResult {
         .into_iter()
         .map(|v| hex::encode(v))
         .collect();
+
+    let external_keys = token
+        .external_public_keys()
+        .into_iter()
+        .map(|ok| ok.map(|bytes| hex::encode(bytes)))
+        .collect();
+
     ParseResult {
         token_blocks,
-        //key: "".to_string(),
         revocation_ids,
+        external_keys,
         error: None,
     }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.3.7",
+  "version": "0.4.0-alpha1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds _basic_ support for third-party tokens, by:

- being able to parse v4 tokens
- being able to generate tokens with scope annotations
- being able to generate tokens with 3rd party blocks (but not attenuate existing tokens with 3rd party blocks)
- being able to authorizer v4 tokens