### PR TITLE
Expose Public Key derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,11 +25,11 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "biscuit-auth"
-version = "3.0.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#f38d100da35605464fa4423f0cbd3c71463d5c39"
+version = "3.0.0-alpha4"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#b723c633f10f587f93b3fa9365e376b60859aa9c"
 dependencies = [
  "base64",
- "biscuit-parser",
+ "biscuit-parser 0.1.0-alpha4",
  "biscuit-quote",
  "ed25519-dalek",
  "getrandom",
@@ -62,12 +62,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "biscuit-quote"
-version = "0.2.0-alpha1"
-source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=master#f38d100da35605464fa4423f0cbd3c71463d5c39"
+name = "biscuit-parser"
+version = "0.1.0-alpha4"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#b723c633f10f587f93b3fa9365e376b60859aa9c"
 dependencies = [
- "biscuit-parser",
+ "hex",
+ "nom",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "biscuit-quote"
+version = "0.2.0-alpha5"
+source = "git+https://github.com/biscuit-auth/biscuit-rust?branch=main#b723c633f10f587f93b3fa9365e376b60859aa9c"
+dependencies = [
+ "biscuit-parser 0.1.0-alpha4",
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -78,7 +93,7 @@ version = "0.4.0-alpha1"
 dependencies = [
  "base64",
  "biscuit-auth",
- "biscuit-parser",
+ "biscuit-parser 0.1.0-alpha1",
  "console_error_panic_hook",
  "hex",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
-biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "master", features = ["wasm", "serde-error"] }
+biscuit-auth = { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "main", features = ["wasm", "serde-error"] }
 biscuit-parser= { git = "https://github.com/biscuit-auth/biscuit-rust", branch = "master", features = ["serde-error"] }
 rand = "0.7"
 log = "0.4"

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -71,7 +71,7 @@ pub fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors
 
     let deser: Result<Biscuit, error::Token> = public_key
         .clone()
-        .and_then(|pk| Biscuit::from_base64(&query.token, |_| pk));
+        .and_then(|pk| Biscuit::from_base64(&query.token, pk));
 
     let authorizer = parse_authorizer(&query.authorizer_code);
 

--- a/src/generate_token.rs
+++ b/src/generate_token.rs
@@ -20,6 +20,7 @@ pub struct GenerateToken {
 pub enum GenerateTokenError {
     Parse(ParseErrors),
     Biscuit(error::Token),
+    KeyPairError(error::Format),
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +38,14 @@ pub fn generate_keypair() -> JsValue {
         public_key: kp.public().to_bytes_hex(),
     })
     .unwrap()
+}
+
+#[wasm_bindgen]
+pub fn get_public_key(private_key: String) -> Result<String, JsValue> {
+    let private = PrivateKey::from_bytes_hex(private_key.as_str())
+        .map_err(|err| JsValue::from_serde(&GenerateTokenError::KeyPairError(err)).unwrap())?;
+    let public = private.public();
+    Ok(public.to_bytes_hex())
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
**Why this PR**

In order to full fill https://github.com/biscuit-auth/biscuit-web-components/pull/25

I need this PR to be merge, because the component use the `get_public_key` method to derive external private as public key in order to be used a trusting source inside the authorizer.