### PR TITLE
0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "biscuit-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
the npm release was issued with an outdated tarball. It has been deprecated.