### PR TITLE
biscuit v3.3 support with biscuit-auth 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.6.0-alpha.1"
+version = "0.6.0-beta.1"
 dependencies = [
  "base64",
  "biscuit-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -31,23 +37,28 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "biscuit-auth"
-version = "5.0.0"
+version = "6.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95490f2c91dc452247d00a2fb4779bcedb7693e669354fa1fe2a96679f4950cc"
+checksum = "5c201f713f0a77e455f9bfd74bc47a8c009d41abc6c755fd4d34d72ae593f6a7"
 dependencies = [
  "base64",
  "biscuit-parser",
  "biscuit-quote",
+ "ecdsa",
  "ed25519-dalek",
+ "elliptic-curve",
  "getrandom 0.1.16",
  "hex",
  "nom",
+ "p256",
+ "pkcs8 0.9.0",
  "prost",
  "prost-types",
  "rand",
  "rand_core",
  "regex",
  "serde",
+ "serde_json",
  "sha2 0.9.9",
  "thiserror",
  "time",
@@ -57,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-parser"
-version = "0.1.2"
+version = "0.2.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9fd6da963e73f7e6db729c3bd76784863ba405b15acbbb5cb08ebc2adbd3bf"
+checksum = "9f52db87488d52f9aeb29c6b7294b736c1341b8730fee49cd1681522398bb59b"
 dependencies = [
  "hex",
  "nom",
@@ -72,12 +83,12 @@ dependencies = [
 
 [[package]]
 name = "biscuit-quote"
-version = "0.2.2"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0071fe3634b644a8df1434e3e14841e480c4238059c66a94e479b7eff98c2bd3"
+checksum = "97887efd447743d2f1a545a8eee5afc4315aedb8a6bfa0c4afcb0974a779907a"
 dependencies = [
  "biscuit-parser",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -85,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "biscuit-wasm-support"
-version = "0.5.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "base64",
  "biscuit-auth",
@@ -134,9 +145,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"
@@ -168,11 +179,23 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -209,7 +232,16 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -219,6 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -247,7 +280,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.9",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "serdect",
+ "signature",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -256,7 +306,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -282,6 +332,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sec1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +376,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -324,10 +406,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "itertools"
@@ -340,30 +442,31 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -401,9 +504,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -412,13 +515,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -429,43 +563,49 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
- "zerocopy-derive",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "primeorder"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
+ "elliptic-curve",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -505,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -544,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -556,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -567,18 +707,34 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -587,16 +743,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "semver"
-version = "1.0.23"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.9",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -614,24 +785,34 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -665,7 +846,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -675,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -697,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -708,29 +899,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -749,9 +940,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -765,9 +956,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "version_check"
@@ -789,11 +980,13 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if 1.0.0",
+ "once_cell",
+ "rustversion",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -801,24 +994,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -826,22 +1018,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-logger"
@@ -856,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -916,7 +1111,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.6.0-alpha.1"
+version = "0.6.0-beta.1"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-wasm-support"
-version = "0.5.1"
+version = "0.6.0-alpha.1"
 authors = ["Geoffroy Couprie <contact@geoffroycouprie.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.4.5"
-biscuit-auth = { version = "5.0.0", features = ["wasm", "serde-error"] }
+biscuit-auth = { version = "6.0.0-beta.1", features = ["wasm", "serde-error"] }
 rand = "0.8"
 getrandom = { version = "0.2.10", features = ["js"] }
 log = "0.4"

--- a/src/attenuate.rs
+++ b/src/attenuate.rs
@@ -72,15 +72,15 @@ fn attenuate_token_from_blocks(
         let mut builder = BlockBuilder::new();
 
         for (_, fact) in block_parsed.facts.iter() {
-            builder.add_fact(fact.clone()).unwrap();
+            builder = builder.fact(fact.clone()).unwrap();
         }
 
         for (_, rule) in block_parsed.rules.iter() {
-            builder.add_rule(rule.clone()).unwrap();
+            builder = builder.rule(rule.clone()).unwrap();
         }
 
         for (_, check) in block_parsed.checks.iter() {
-            builder.add_check(check.clone()).unwrap();
+            builder = builder.check(check.clone()).unwrap();
         }
 
         output = output.append(builder)?;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,6 +1,7 @@
 use crate::execute_serialized;
 use crate::generate_token;
 use crate::{Editor, Fact, ParseErrors};
+use biscuit_auth::Algorithm;
 use biscuit_auth::{error, KeyPair};
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -49,11 +50,11 @@ pub fn execute(query: &JsValue) -> JsValue {
 
 fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ParseErrors> {
     let mut rng: StdRng = SeedableRng::seed_from_u64(0);
-    let root_key = KeyPair::new_with_rng(&mut rng);
+    let root_key = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
     let creation_query = generate_token::GenerateToken {
         token_blocks: query.token_blocks.clone(),
         external_private_keys: query.external_private_keys,
-        private_key: root_key.private().to_bytes_hex(),
+        private_key: root_key.private().to_prefixed_string(),
     };
 
     let serialized = generate_token::generate_token_inner(creation_query).map_err(|e| match e {
@@ -64,8 +65,8 @@ fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ParseErrors> {
     let execute_query = execute_serialized::BiscuitQuery {
         token: serialized.clone(),
         token_blocks: Some(query.token_blocks.clone()),
-        root_public_key: root_key.public().to_bytes_hex(),
-        authorizer_code: query.authorizer_code.unwrap_or(String::new()),
+        root_public_key: root_key.public().to_string(),
+        authorizer_code: query.authorizer_code.unwrap_or_default(),
         query: query.query,
     };
 

--- a/src/execute_serialized.rs
+++ b/src/execute_serialized.rs
@@ -2,8 +2,9 @@ use crate::{
     get_parse_errors, get_position, log, Editor, Fact, Marker, ParseError, SourcePosition,
 };
 use biscuit_auth::{
-    builder, error, parser::parse_block_source, parser::parse_source, parser::SourceResult,
-    AuthorizerLimits, Biscuit, PublicKey,
+    builder, error,
+    parser::{parse_block_source, parse_source, SourceResult},
+    AuthorizerBuilder, AuthorizerLimits, Biscuit, PublicKey,
 };
 use serde::{Deserialize, Serialize};
 use std::default::Default;
@@ -61,8 +62,10 @@ pub fn execute_serialized(query: &JsValue) -> JsValue {
 }
 
 pub fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors> {
-    let public_key =
-        PublicKey::from_bytes_hex(&query.root_public_key).map_err(|_| error::Token::InternalError);
+    let public_key: Result<PublicKey, error::Token> = query
+        .root_public_key
+        .parse()
+        .map_err(|_| error::Token::InternalError);
 
     let deser: Result<Biscuit, error::Token> = public_key
         .clone()
@@ -82,7 +85,7 @@ pub fn execute_inner(query: BiscuitQuery) -> Result<BiscuitResult, ExecuteErrors
         Err(ExecuteErrors {
             root_key: public_key.err().map(|e| e.to_string()),
             token: deser.err().map(|e| e.to_string()),
-            authorizer: authorizer.err().unwrap_or(Vec::new()),
+            authorizer: authorizer.err().unwrap_or_default(),
         })
     }
 }
@@ -116,27 +119,27 @@ fn perform_authorization(
         biscuit_result.token_blocks.push(Editor::default());
     }
 
-    let mut authorizer = token.authorizer().unwrap();
+    let mut authorizer_builder = AuthorizerBuilder::new();
     let mut authorizer_checks = Vec::new();
     let mut authorizer_policies = Vec::new();
 
     for (_, fact) in authorizer_source.facts.iter() {
-        authorizer.add_fact(fact.clone()).unwrap();
+        authorizer_builder = authorizer_builder.fact(fact.clone()).unwrap();
     }
 
     for (_, rule) in authorizer_source.rules.iter() {
-        authorizer.add_rule(rule.clone()).unwrap();
+        authorizer_builder = authorizer_builder.rule(rule.clone()).unwrap();
     }
 
     for (i, check) in authorizer_source.checks.iter() {
-        authorizer.add_check(check.clone()).unwrap();
+        authorizer_builder = authorizer_builder.check(check.clone()).unwrap();
         let position = get_position(authorizer_code, i);
         // checks are marked as success until they fail
         authorizer_checks.push((position, true));
     }
 
     for (i, policy) in authorizer_source.policies.iter() {
-        authorizer.add_policy(policy.clone()).unwrap();
+        authorizer_builder = authorizer_builder.policy(policy.clone()).unwrap();
         let position = get_position(authorizer_code, i);
         authorizer_policies.push(position);
     }
@@ -145,6 +148,7 @@ fn perform_authorization(
         max_time: std::time::Duration::from_secs(2),
         ..Default::default()
     };
+    let mut authorizer = authorizer_builder.build(token).unwrap();
     let authorizer_result = authorizer.authorize_with_limits(limits);
 
     // todo extract scope information as well

--- a/src/generate_token.rs
+++ b/src/generate_token.rs
@@ -34,19 +34,30 @@ pub fn generate_keypair() -> JsValue {
     let kp = KeyPair::new();
 
     serde_wasm_bindgen::to_value(&KeyPairJs {
-        private_key: kp.private().to_bytes_hex(),
-        public_key: kp.public().to_bytes_hex(),
+        private_key: kp.private().to_prefixed_string(),
+        public_key: kp.public().to_string(),
+    })
+    .unwrap()
+}
+
+#[wasm_bindgen]
+pub fn generate_ecdsa_keypair() -> JsValue {
+    let kp = KeyPair::new_with_algorithm(biscuit_auth::Algorithm::Secp256r1);
+
+    serde_wasm_bindgen::to_value(&KeyPairJs {
+        private_key: kp.private().to_prefixed_string(),
+        public_key: kp.public().to_string(),
     })
     .unwrap()
 }
 
 #[wasm_bindgen]
 pub fn get_public_key(private_key: String) -> Result<String, JsValue> {
-    let private = PrivateKey::from_bytes_hex(private_key.as_str()).map_err(|err| {
+    let private: PrivateKey = private_key.as_str().parse().map_err(|err| {
         serde_wasm_bindgen::to_value(&GenerateTokenError::KeyPairError(err)).unwrap()
     })?;
     let public = private.public();
-    Ok(public.to_bytes_hex())
+    Ok(public.to_string())
 }
 
 #[wasm_bindgen]
@@ -87,7 +98,7 @@ pub fn generate_token_inner(query: GenerateToken) -> Result<String, GenerateToke
             .into_iter()
             .map(|ok| {
                 let res = ok.map(|k| {
-                    PrivateKey::from_bytes_hex(&k)
+                    k.parse()
                         .map_err(|_| GenerateTokenError::Biscuit(error::Token::InternalError))
                         .map(|pk| KeyPair::from(&pk))
                 });
@@ -108,21 +119,21 @@ fn generate_token_from_blocks(
     blocks: Vec<SourceResult>,
     external_private_keys: Vec<Option<KeyPair>>,
 ) -> Result<String, error::Token> {
-    let keypair = KeyPair::from(&PrivateKey::from_bytes_hex(&query.private_key)?);
+    let keypair = KeyPair::from(&query.private_key.parse()?);
     let mut builder = Biscuit::builder();
 
     let authority_parsed = &blocks[0];
 
     for (_, fact) in authority_parsed.facts.iter() {
-        builder.add_fact(fact.clone()).unwrap();
+        builder = builder.fact(fact.clone()).unwrap();
     }
 
     for (_, rule) in authority_parsed.rules.iter() {
-        builder.add_rule(rule.clone()).unwrap();
+        builder = builder.rule(rule.clone()).unwrap();
     }
 
     for (_, check) in authority_parsed.checks.iter() {
-        builder.add_check(check.clone()).unwrap();
+        builder = builder.check(check.clone()).unwrap();
     }
 
     let mut token = builder.build(&keypair)?;
@@ -136,15 +147,15 @@ fn generate_token_from_blocks(
             let mut builder = BlockBuilder::new();
 
             for (_, fact) in block_parsed.facts.iter() {
-                builder.add_fact(fact.clone()).unwrap();
+                builder = builder.fact(fact.clone()).unwrap();
             }
 
             for (_, rule) in block_parsed.rules.iter() {
-                builder.add_rule(rule.clone()).unwrap();
+                builder = builder.rule(rule.clone()).unwrap();
             }
 
             for (_, check) in block_parsed.checks.iter() {
-                builder.add_check(check.clone()).unwrap();
+                builder = builder.check(check.clone()).unwrap();
             }
 
             let block = req.create_block(&epk.private(), builder)?;
@@ -153,15 +164,15 @@ fn generate_token_from_blocks(
             let mut builder = BlockBuilder::new();
 
             for (_, fact) in block_parsed.facts.iter() {
-                builder.add_fact(fact.clone()).unwrap();
+                builder = builder.fact(fact.clone()).unwrap();
             }
 
             for (_, rule) in block_parsed.rules.iter() {
-                builder.add_rule(rule.clone()).unwrap();
+                builder = builder.rule(rule.clone()).unwrap();
             }
 
             for (_, check) in block_parsed.checks.iter() {
-                builder.add_check(check.clone()).unwrap();
+                builder = builder.check(check.clone()).unwrap();
             }
             token = token.append(builder)?;
         }

--- a/src/parse_snapshot.rs
+++ b/src/parse_snapshot.rs
@@ -7,7 +7,6 @@ use wasm_bindgen::prelude::*;
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 struct InspectSnapshotQuery {
     pub data: String,
-    pub extra_authorizer: Option<String>,
     pub query: Option<String>,
 }
 
@@ -20,7 +19,7 @@ struct InspectionResult {
 struct ParseResult {
     pub code: String,
     pub iterations: u64,
-    pub elapsed_micros: u128,
+    pub elapsed_micros: Option<u128>,
     pub authorization_result: Result<usize, error::Token>,
     pub query_result: Option<Result<Vec<Fact>, error::Token>>,
 }
@@ -45,22 +44,13 @@ fn inspect_snapshot_inner(query: InspectSnapshotQuery) -> Result<ParseResult, er
         new_authorizer.to_string()
     };
     let iterations = authorizer.iterations();
-    let elapsed_micros = authorizer.execution_time().as_micros();
+    let elapsed_micros = authorizer.execution_time().map(|d| d.as_micros());
 
     let authorization_result = {
-        if let Some(extra_code) = query.extra_authorizer {
-            authorizer.add_code(extra_code).and_then(|()| {
-                authorizer.authorize_with_limits(RunLimits {
-                    max_time: Duration::from_millis(100),
-                    ..Default::default()
-                })
-            })
-        } else {
-            authorizer.authorize_with_limits(RunLimits {
-                max_time: Duration::from_millis(100),
-                ..Default::default()
-            })
-        }
+        authorizer.authorize_with_limits(RunLimits {
+            max_time: Duration::from_millis(100),
+            ..Default::default()
+        })
     };
 
     let query_result = query.query.map(|q| authorizer.query(q.as_str()));

--- a/src/parse_token.rs
+++ b/src/parse_token.rs
@@ -50,7 +50,7 @@ fn parse_token_inner(query: ParseTokenQuery) -> ParseResult {
     let external_keys = token
         .external_public_keys()
         .into_iter()
-        .map(|ok| ok.map(hex::encode))
+        .map(|ok| ok.map(|pk| pk.to_string()))
         .collect();
 
     ParseResult {

--- a/web/package.json
+++ b/web/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@biscuit-auth/biscuit-wasm-support",
+  "type": "module",
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.5.1",
+  "version": "0.6.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -15,7 +16,7 @@
     "biscuit.d.ts",
     "snippets"
   ],
-  "module": "biscuit.js",
+  "main": "biscuit.js",
   "types": "biscuit.d.ts",
   "sideEffects": [
     "./snippets/*"

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "collaborators": [
     "Geoffroy Couprie <contact@geoffroycouprie.com>"
   ],
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- remove the ability to add code to an existing authorizer snapshot
- follow builder APIs changes
- set the key algorithms explictly

## TODO

- [x] wait for https://github.com/biscuit-auth/biscuit-rust/pull/261 and handle keys with prefixes
- [x] wait for a proper (ie not alpha) biscuit-auth release